### PR TITLE
Locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,5 @@ docker-compose run web bundle exec rails g controller admins
 コンテナのbashに接続
 docker exec -it  qr-timecard-ver2_web_1 bash
 bundle exec rails c
+
+docker attach qr-timecard-ver2_web_1

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -10,6 +10,6 @@ class AdminsController < ApplicationController
   private
 
   def admin_params
-    params.require(:admin).permit[:id, :company_name, :company_name_kana]
+    params.require(:admin).permit[:company_name, :company_name_kana]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,18 @@
 class ApplicationController < ActionController::Base
-  # protect_from_forgery with: :exception
+  protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
+  #以下はいらない？
   # before_action :current_locale
   # before_action :require_sign_in!
   # helper_method :sign_in?
+
+  #controllerを判別する
+  def request_path
+    @path = controller_path + '#' + action_name
+    def @path.is(*str)
+      str.map{|s| self.include?(s)}.include?(true)
+    end
+  end
 
   def after_sign_in_path_for(resource)
     if admin_signed_in?
@@ -16,7 +25,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sing_out_path_for(resource)
-    root_path
+    admin_session_path
   end
 
   def current_locale
@@ -24,22 +33,23 @@ class ApplicationController < ActionController::Base
     @current_locale ||= Locale.find_by(remember_token: remember_token)
   end
 
-#remenber_tokenを作成し、localeモデルとcookieにセットし、login後の画面に遷移
-  # def sign_in(locale)
-  #   remember_token = Locale.new_remember_token
-  #   cookies.permanent[:locale_remember_token] = remember_token
-  #   locale.update!(remember_token: Locale.encrypt(remember_token))
-  #   @current_locale = locale
-  # end
+    #remenber_tokenを作成し、localeモデルとcookieにセットする
+    def locale_sign_in(locale)
+      remember_token = Locale.new_remember_token
+      cookies.permanent[:locale_remember_token] = remember_token
+      locale.update!(remember_token: Locale.encrypt(remember_token))
+      @current_locale = locale
+    end
 
-  def sign_out
-    @current_locale = nil
-    cookies.delete(:locale_remember_token)
-  end
+    #ログアウト処理
+    def locale_sign_out
+      @current_locale = nil
+      cookies.delete(:locale_remember_token)
+    end
 
-  def signd_in?
-    @current_locale.present?
-  end
+    def signd_in?
+      @current_locale.present?
+    end
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,10 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  # protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
   # before_action :current_locale
   # before_action :require_sign_in!
   # helper_method :sign_in?
+
   def after_sign_in_path_for(resource)
     if admin_signed_in?
       admin_path(id: current_admin[:id])
@@ -18,26 +19,27 @@ class ApplicationController < ActionController::Base
     root_path
   end
 
-  # def current_locale
-  #   remember_token = Locale.encrypt(cookies[:locale_remember_token])
-  #   @current_locale ||= Locale.find_by(remember_token: remember_token)
-  # end
+  def current_locale
+    remember_token = Locale.encrypt(cookies[:locale_remember_token])
+    @current_locale ||= Locale.find_by(remember_token: remember_token)
+  end
 
+#remenber_tokenを作成し、localeモデルとcookieにセットし、login後の画面に遷移
   # def sign_in(locale)
-  #   remenber_token = Locale.new_remember_token
-  #   cookies.permanent[:locale_remember] = new_remember_token
-  #   locale.update!(remember_token: Locale.encrypt(remenber_token))
+  #   remember_token = Locale.new_remember_token
+  #   cookies.permanent[:locale_remember_token] = remember_token
+  #   locale.update!(remember_token: Locale.encrypt(remember_token))
   #   @current_locale = locale
   # end
 
-  # def sign_out
-  #   @current_locale = nil
-  #   cookies.delete(:locale_remember_token)
-  # end
+  def sign_out
+    @current_locale = nil
+    cookies.delete(:locale_remember_token)
+  end
 
-  # def signd_in?
-  #   @current_locale.present?
-  # end
+  def signd_in?
+    @current_locale.present?
+  end
 
   private
 
@@ -55,9 +57,9 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # def require_sign_in!
-  #   redirect_to login_path unless signed_in?
-  # end
+  def require_sign_in!
+    redirect_to login_path unless signed_in?
+  end
 
   protected
 

--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -1,8 +1,16 @@
 class LocalesController < ApplicationController
-  # skip_before_action :require_sign_in!, only: [:new, :create]
+  before_action :current_locale
+  before_action :require_sign_in!
+  helper_method :sign_in?
+
+  skip_before_action :require_sign_in!, only: [:new, :create]
 
   def index
     @locale = Locale.all
+  end
+
+  def show
+    
   end
 
   def new
@@ -11,6 +19,7 @@ class LocalesController < ApplicationController
 
   def create
     @locale = Locale.new(locale_params)
+    # binding.pry
     if @locale.save
       redirect_to login_path
     else

--- a/app/controllers/locales_controller.rb
+++ b/app/controllers/locales_controller.rb
@@ -1,16 +1,15 @@
 class LocalesController < ApplicationController
   before_action :current_locale
-  before_action :require_sign_in!
+  # before_action :require_sign_in!
   helper_method :sign_in?
-
-  skip_before_action :require_sign_in!, only: [:new, :create]
+  skip_before_action :require_sign_in!, only: [:new, :create], raise: false
 
   def index
     @locale = Locale.all
   end
 
   def show
-    
+    @locale = Locale.find(params[:id])
   end
 
   def new
@@ -19,9 +18,9 @@ class LocalesController < ApplicationController
 
   def create
     @locale = Locale.new(locale_params)
-    # binding.pry
+    #errorがなければsaveして、passwordはpassword_digestに暗号化され保存される
     if @locale.save
-      redirect_to login_path
+      redirect_to login_path(@locale)
     else
       render 'new'
     end
@@ -34,7 +33,7 @@ class LocalesController < ApplicationController
     params.require(:locale).permit(:locale_name, :admin_id, :control_number, :password, :password_confirmation)
   end
 
-  def admin_params
-    params.require(:admin).permit(:id, :company_name)
-  end
+  # def admin_params
+  #   params.require(:admin).permit(:id, :company_name)
+  # end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,10 @@
 class SessionsController < ApplicationController
-  # skip_before_action :require_sign_in!, only: [:new, :create]
-  # before_action :set_user, only:[:create]
+  before_action :current_locale
+  before_action :require_sign_in!
+  helper_method :sign_in?
+
+  skip_before_action :require_sign_in!, only: [:new, :create]
+  before_action :set_locale, only:[:create]
 
   def new
   end
@@ -11,7 +15,7 @@ class SessionsController < ApplicationController
       redirect_to root_path
     else
       flash.now[:danger] = t('.flash.invaled_password')
-      render 'sessions#new'
+      render 'new'
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,27 +1,29 @@
 class SessionsController < ApplicationController
-  before_action :current_locale
-  before_action :require_sign_in!
-  helper_method :sign_in?
-
-  skip_before_action :require_sign_in!, only: [:new, :create]
+  # before_action :current_locale
+  skip_before_action :require_sign_in!, only: [:create], raise: false
   before_action :set_locale, only:[:create]
+  helper_method :sign_in?
 
   def new
   end
 
+  #ログイン画面で入力された値を検証
   def create
+  #authenticateメソッドで入力されたpasswordを暗号化し、DBのpassword_digestと一致するかを検証
     if @locale.authenticate(session_params[:password])
-      sign_in(@locale)
-      redirect_to root_path
+      #検証が通ればsing_inメソッドを呼び出し、remember_tokenを作成し、localeモデルのcookieにセットし、ログイン後の画面に遷移
+      locale_sign_in(@locale)
+      redirect_to locale_path(@locale[:id])
     else
       flash.now[:danger] = t('.flash.invaled_password')
       render 'new'
     end
   end
 
+  #ログアウト処理
   def destroy
-    sign_out
-    redirect_to login_path
+    locale_sign_out
+    redirect_to root_path
   end
 
   private

--- a/app/models/locale.rb
+++ b/app/models/locale.rb
@@ -19,7 +19,10 @@
 #
 
 class Locale < ApplicationRecord
+  #passwordの入力必須
   has_secure_password validations: true
+  #admin_idが同じ場合にcontroller_numberをunique: trueにしたい
+  #validates :
   validates :admin_id,presence: true
 
   def self.new_remember_token

--- a/app/models/locale.rb
+++ b/app/models/locale.rb
@@ -20,7 +20,7 @@
 
 class Locale < ApplicationRecord
   has_secure_password validations: true
-  validates :admin_id,presence: true, uniqueness: true
+  validates :admin_id,presence: true
 
   def self.new_remember_token
     SecureRandom.urlsafe_base64

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
       <nav class="navbar sticky-top" style="background-color:#ff8e00;">
         <a class="navbar-brand" href="#">
           <% if admin_signed_in? %>
-            <%= @admin.company_name %>
+            <%= current_admin.company_name %>
           <% else %>
             Kintaiくん
           <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,12 +12,11 @@
   <body>
     <header>
       <nav class="navbar sticky-top" style="background-color:#ff8e00;">
-        <a class="navbar-brand" href="#">
-          <% if admin_signed_in? %>
-            <%= current_admin.company_name %>
-          <% else %>
-            Kintaiくん
-          <% end %>
+        <% if admin_signed_in? %>
+          <%= link_to "#{current_admin.company_name}", admin_path(current_admin) %>
+        <% else %>
+          <p>Kintaiくん</p>
+        <% end %>
         </a>
         <div class="nav-item">
           <% if admin_signed_in? || manager_signed_in? %>
@@ -30,6 +29,7 @@
             <%= link_to "管理者登録", new_admin_registration_path, class: "nav-item btn btn-outline-dark" %>
             <%= link_to "管理者ログイン", new_admin_session_path, class: "nav-item btn btn-outline-dark" %>
             <%= link_to "managerログイン", manager_session_path, class: "nav-item btn btn-outline-dark" %>
+            <%= link_to "localeログイン", login_path, class: "nav-item btn btn-outline-dark" %>
           <% end %>
         </div>
       </nav>

--- a/app/views/locales/show.html.erb
+++ b/app/views/locales/show.html.erb
@@ -1,0 +1,3 @@
+<%= link_to "ログアウト", logout_path, class: "btn btn-outline-danger", method: :delete %>
+<%= @locale.locale_name %>
+<%= @locale.admin_id %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,7 +1,8 @@
-<%= form_for :session, url: new_locale_path do |f| %>
+<%= form_for :session, url: login_path do |f| %>
 <%= f.label :管理番号 %>
-<%= f.text_field :controller_number, class: "form-control" %>
+<%= f.text_field :control_number, class: "form-control" %>
 
 <%= f.label :パスワード %>
 <%= f.password_field :password, class: "form-control" %>
 <%= f.submit :ログイン, class: "btn btn-info" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
   resources :managers, only:[:show]
   resources :locales, only:[:index, :new, :create, :show]
 
-  get 'login', to: 'sessions#new'
-  post 'login', to: 'sessions#create'
-  delete 'logout', to: 'sessions#destroy'
-
+  #localeでのログイン/ログアウト
+  get 'login', to: 'sessions#new' #mailとpasswordをnewで入力させる
+  post 'login', to: 'sessions#create' #入力された情報を検証し、cookieにログイン情報を格納する
+  delete 'logout', to: 'sessions#destroy' #ログアウトさせる
 end


### PR DESCRIPTION
adminのログアウトとlocaleのログアウトが干渉してadminがログアウト出来なかったのを解消
deviseを使用して、スクラッチのアカウント管理も実装する際、application_controllerにsing_outアクションを作るとdeviseでもそっちを実行してしまい、devise(admin)がログアウト出来ない。
action nameに気をつける必要あり。
